### PR TITLE
fix(ci): capture benchmark output from stderr in workflow

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -29,7 +29,7 @@ jobs:
         run: cargo install critcmp
 
       - name: Run benchmarks
-        run: cargo bench --all-features -- --save-baseline current --output-format bencher 2>/dev/null | tee bench-output.txt
+        run: cargo bench --all-features -- --save-baseline current --output-format bencher 2>&1 | tee bench-output.txt
 
       # ── Push to main: update timeline + cache baseline ──
 


### PR DESCRIPTION
## Summary

- Fix benchmark CI workflow to correctly capture Criterion output by redirecting stderr to stdout (`2>&1`) instead of discarding it (`2>/dev/null`), since Criterion writes benchmark results to stderr.

## Changes

- `.github/workflows/benchmarks.yml`: Change `2>/dev/null` to `2>&1` in the benchmark run step so that `tee bench-output.txt` captures the actual benchmark output.

