### PR TITLE
fix(ci): exclude lib target from cargo bench to fix benchmark CI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,9 @@ keywords = ["scheduler", "priority-queue", "task", "async"]
 categories = ["asynchronous", "concurrency"]
 repository = "https://github.com/deepjoy/taskmill"
 
+[lib]
+bench = false
+
 [features]
 default = ["sysinfo-monitor"]
 sysinfo-monitor = ["dep:sysinfo"]


### PR DESCRIPTION
The default libtest harness for src/lib.rs does not support --output-format bencher, causing cargo bench to exit non-zero. Setting bench = false on [lib] ensures only the named criterion bench targets are run.
