### PR TITLE
fix(ci): restore stderr capture for benchmark output on main

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -32,7 +32,7 @@ jobs:
         run: cargo bench --all-features --no-run
 
       - name: Run benchmarks
-        run: cargo bench --all-features -- --save-baseline current --output-format bencher 2>/dev/null | tee bench-output.txt
+        run: cargo bench --all-features -- --save-baseline current --output-format bencher 2>&1 | tee bench-output.txt
 
       # ── Push to main: update timeline + cache baseline ──
 


### PR DESCRIPTION
PR #48 accidentally reverted the `2>&1` fix from PR #47. Criterion writes bencher-format output to stderr, so `2>/dev/null` was silently discarding it, leaving bench-output.txt empty on push-to-main runs.

The github-action-benchmark step only runs on push events, so PR runs never exercised the broken path — the failure only surfaced after merge.
