### PR TITLE
fix(ci): bootstrap _benchmarks branch on first push to main

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -36,6 +36,10 @@ jobs:
 
       # ── Push to main: update timeline + cache baseline ──
 
+      - name: Ensure _benchmarks branch exists
+        if: github.event_name == 'push'
+        run: git fetch origin _benchmarks:_benchmarks 2>/dev/null || git push origin HEAD:refs/heads/_benchmarks
+
       - name: Update benchmark timeline
         if: github.event_name == 'push'
         uses: benchmark-action/github-action-benchmark@v1


### PR DESCRIPTION
The github-action-benchmark step was failing with
"fatal: couldn't find remote ref _benchmarks" because the branch had never been created. Add a step that fetches the branch if it exists, or creates it from HEAD on first run.
