### PR TITLE
fix(bench): remove premature cancellation token call in history benchmark setup

### DIFF
--- a/benches/history.rs
+++ b/benches/history.rs
@@ -56,7 +56,6 @@ async fn build_scheduler_with_history(n: usize) -> Scheduler {
         }
     }
 
-    token.cancel();
     sched
 }
 


### PR DESCRIPTION
- Removes the `token.cancel()` call from `build_scheduler_with_history` in `benches/history.rs`

## Details

The `token.cancel()` was being called immediately after all tasks completed,
but before the `Scheduler` was returned to the benchmark harness. This caused
the scheduler's background `run` loop to be shut down prematurely — before
benchmarks had a chance to query history — leading to potential race conditions
or inaccurate measurements.

