### PR TITLE
perf: reduce SQL round-trips and CPU overhead in scheduler hot paths

### DIFF
--- a/src/scheduler/builder.rs
+++ b/src/scheduler/builder.rs
@@ -402,6 +402,7 @@ impl SchedulerBuilder {
         };
 
         // Build gate from pressure sources + policy.
+        let has_pressure = !self.pressure_sources.is_empty();
         let mut pressure = CompositePressure::new();
         for source in self.pressure_sources {
             pressure.add_source(source);
@@ -434,6 +435,12 @@ impl SchedulerBuilder {
             module_registry,
             module_state,
         );
+
+        // Compute fast-dispatch eligibility before consuming builder fields.
+        let has_groups =
+            self.default_group_concurrency > 0 || !self.group_concurrency_overrides.is_empty();
+        let has_monitoring = self.enable_resource_monitoring;
+        let has_module_caps = !scheduler.inner.module_caps.read().unwrap().is_empty();
 
         // Apply group concurrency limits.
         if self.default_group_concurrency > 0 {
@@ -472,6 +479,16 @@ impl SchedulerBuilder {
                 sampler_config,
                 sampler_token,
             ));
+        }
+
+        // Enable fast dispatch (single pop_next instead of peek + gate + claim)
+        // when no groups, no resource monitoring, no pressure sources, and no
+        // module caps are configured.
+        if !has_groups && !has_monitoring && !has_pressure && !has_module_caps {
+            scheduler
+                .inner
+                .fast_dispatch
+                .store(true, std::sync::atomic::Ordering::Relaxed);
         }
 
         Ok(scheduler)

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -133,6 +133,11 @@ pub(crate) struct SchedulerInner {
     /// Cleared when `paused_tasks()` returns empty. Avoids a SQL round-trip
     /// per dispatch cycle when no tasks are paused.
     pub(crate) has_paused_tasks: AtomicBool,
+    /// Fast-dispatch mode: when `true`, `try_dispatch` uses `pop_next()`
+    /// (single SQL) instead of `peek_next()` + gate + `claim_task()` (2 SQL).
+    /// Computed at build time: `true` when no groups, no resource monitoring,
+    /// and no module concurrency caps are configured.
+    pub(crate) fast_dispatch: AtomicBool,
     /// Send side of the completion coalescing channel.
     pub(crate) completion_tx: tokio::sync::mpsc::UnboundedSender<CompletionMsg>,
     /// Receive side, `Arc`-wrapped so spawned tasks can try to drain the batch
@@ -268,6 +273,8 @@ impl Scheduler {
                 module_running,
                 // Conservative: true on startup so the first cycle checks.
                 has_paused_tasks: AtomicBool::new(true),
+                // Default to false; builder sets true when safe.
+                fast_dispatch: AtomicBool::new(false),
                 completion_tx,
                 completion_rx: std::sync::Arc::new(Mutex::new(completion_rx)),
             }),

--- a/src/scheduler/run_loop.rs
+++ b/src/scheduler/run_loop.rs
@@ -47,7 +47,17 @@ impl Scheduler {
             return Ok(false);
         }
 
-        // Peek at the next candidate without changing its status.
+        // Fast path: no gate checks needed, use pop_next() (single SQL)
+        // instead of peek_next() + gate.admit() + claim_task() (2 SQL).
+        // pop_next() skips expired tasks via its WHERE clause.
+        if self.inner.fast_dispatch.load(AtomicOrdering::Relaxed) {
+            let Some(task) = self.inner.store.pop_next().await? else {
+                return Ok(false);
+            };
+            return self.spawn_dispatched_task(task).await;
+        }
+
+        // Slow path: peek → gate check → claim.
         let Some(candidate) = self.inner.store.peek_next().await? else {
             return Ok(false);
         };
@@ -102,6 +112,14 @@ impl Scheduler {
             }
         }
 
+        self.spawn_dispatched_task(task).await
+    }
+
+    /// Look up executor and spawn a task that is already in the `running` state.
+    async fn spawn_dispatched_task(
+        &self,
+        task: crate::task::TaskRecord,
+    ) -> Result<bool, StoreError> {
         // Look up executor.
         let Some(executor) = self.inner.registry.get(&task.task_type) else {
             tracing::error!(

--- a/src/scheduler/spawn/completion.rs
+++ b/src/scheduler/spawn/completion.rs
@@ -37,7 +37,13 @@ pub(crate) async fn handle_success(
 
     // For the execute phase, check if the task spawned children.
     // If so, transition to waiting instead of completing.
-    if phase == ExecutionPhase::Execute {
+    // Skip the DB query entirely when no tasks have been submitted with parent_id.
+    if phase == ExecutionPhase::Execute
+        && deps
+            .store
+            .has_hierarchy
+            .load(std::sync::atomic::Ordering::Relaxed)
+    {
         match deps.store.active_children_count(task_id).await {
             Ok(count) if count > 0 => {
                 if let Err(e) = deps.store.set_waiting(task_id).await {

--- a/src/store/dependencies.rs
+++ b/src/store/dependencies.rs
@@ -20,48 +20,45 @@ impl TaskStore {
     }
 
     /// Inner dependency resolution that runs within an existing transaction.
+    ///
+    /// Uses `DELETE ... RETURNING` to combine edge lookup + deletion into a
+    /// single query, then a single batched `UPDATE ... RETURNING` to unblock
+    /// all dependents whose remaining deps are now zero.
     pub(crate) async fn resolve_dependents_inner(
         conn: &mut sqlx::pool::PoolConnection<sqlx::Sqlite>,
         completed_task_id: i64,
     ) -> Result<Vec<i64>, StoreError> {
-        // Find tasks that depend on the completed task.
+        // Step 1: Delete satisfied edges and collect affected task IDs.
         let dependent_ids: Vec<(i64,)> =
-            sqlx::query_as("SELECT task_id FROM task_deps WHERE depends_on_id = ?")
+            sqlx::query_as("DELETE FROM task_deps WHERE depends_on_id = ? RETURNING task_id")
                 .bind(completed_task_id)
                 .fetch_all(&mut **conn)
                 .await?;
 
-        // Remove the satisfied edges.
-        sqlx::query("DELETE FROM task_deps WHERE depends_on_id = ?")
-            .bind(completed_task_id)
-            .execute(&mut **conn)
-            .await?;
-
-        let mut unblocked = Vec::new();
-
-        for (dep_id,) in dependent_ids {
-            // Check if this dependent has any remaining unresolved deps.
-            let (remaining,): (i64,) =
-                sqlx::query_as("SELECT COUNT(*) FROM task_deps WHERE task_id = ?")
-                    .bind(dep_id)
-                    .fetch_one(&mut **conn)
-                    .await?;
-
-            if remaining == 0 {
-                // All deps satisfied — unblock.
-                let result = sqlx::query(
-                    "UPDATE tasks SET status = 'pending' WHERE id = ? AND status = 'blocked'",
-                )
-                .bind(dep_id)
-                .execute(&mut **conn)
-                .await?;
-                if result.rows_affected() > 0 {
-                    unblocked.push(dep_id);
-                }
-            }
+        if dependent_ids.is_empty() {
+            return Ok(Vec::new());
         }
 
-        Ok(unblocked)
+        // Step 2: Unblock tasks with zero remaining deps in one UPDATE.
+        let placeholders = dependent_ids
+            .iter()
+            .map(|_| "?")
+            .collect::<Vec<_>>()
+            .join(",");
+        let sql = format!(
+            "UPDATE tasks SET status = 'pending'
+             WHERE status = 'blocked'
+               AND id IN ({placeholders})
+               AND NOT EXISTS (SELECT 1 FROM task_deps WHERE task_deps.task_id = tasks.id)
+             RETURNING id"
+        );
+        let mut q = sqlx::query_as::<_, (i64,)>(&sql);
+        for (dep_id,) in &dependent_ids {
+            q = q.bind(dep_id);
+        }
+        let unblocked: Vec<(i64,)> = q.fetch_all(&mut **conn).await?;
+
+        Ok(unblocked.into_iter().map(|(id,)| id).collect())
     }
 
     /// After a task permanently fails, propagate failure to blocked dependents.
@@ -93,17 +90,12 @@ impl TaskStore {
         Box<dyn std::future::Future<Output = Result<(Vec<i64>, Vec<i64>), StoreError>> + Send + 'a>,
     > {
         Box::pin(async move {
+            // Delete edges from the failed task and collect affected task IDs.
             let dependent_rows: Vec<(i64,)> =
-                sqlx::query_as("SELECT task_id FROM task_deps WHERE depends_on_id = ?")
+                sqlx::query_as("DELETE FROM task_deps WHERE depends_on_id = ? RETURNING task_id")
                     .bind(failed_task_id)
                     .fetch_all(&mut **conn)
                     .await?;
-
-            // Clean up edges from the failed task.
-            sqlx::query("DELETE FROM task_deps WHERE depends_on_id = ?")
-                .bind(failed_task_id)
-                .execute(&mut **conn)
-                .await?;
 
             let mut all_failed = Vec::new();
             let mut all_unblocked = Vec::new();

--- a/src/store/lifecycle/mod.rs
+++ b/src/store/lifecycle/mod.rs
@@ -62,7 +62,7 @@ pub(crate) async fn insert_history(
     } else {
         task.retry_count
     };
-    sqlx::query(
+    let result = sqlx::query(
         "INSERT INTO task_history (task_type, key, label, priority, status, payload,
             expected_read_bytes, expected_write_bytes, expected_net_rx_bytes, expected_net_tx_bytes,
             actual_read_bytes, actual_write_bytes, actual_net_rx_bytes, actual_net_tx_bytes,
@@ -110,9 +110,7 @@ pub(crate) async fn insert_history(
     .await?;
 
     // Copy tags from task_tags to task_history_tags.
-    let history_rowid = sqlx::query_scalar::<_, i64>("SELECT last_insert_rowid()")
-        .fetch_one(&mut **conn)
-        .await?;
+    let history_rowid = result.last_insert_rowid();
     sqlx::query(
         "INSERT INTO task_history_tags (history_rowid, key, value)
          SELECT ?, key, value FROM task_tags WHERE task_id = ?",

--- a/src/store/lifecycle/transitions.rs
+++ b/src/store/lifecycle/transitions.rs
@@ -122,6 +122,7 @@ impl TaskStore {
                  SELECT id FROM tasks
                  WHERE status = 'pending'
                    AND (run_after IS NULL OR run_after <= strftime('%Y-%m-%d %H:%M:%f', 'now'))
+                   AND (expires_at IS NULL OR expires_at > strftime('%Y-%m-%d %H:%M:%f', 'now'))
                  ORDER BY priority ASC, id ASC
                  LIMIT 1
              )

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -168,6 +168,9 @@ pub struct TaskStore {
     /// Fast-path flag: `false` means no tags have been inserted into
     /// `task_tags`, so `populate_tags` can skip the query entirely.
     pub(crate) has_tags: std::sync::Arc<AtomicBool>,
+    /// Fast-path flag: `false` means no tasks with `parent_id` have been
+    /// submitted, so `active_children_count` checks can be skipped.
+    pub(crate) has_hierarchy: std::sync::Arc<AtomicBool>,
 }
 
 impl TaskStore {
@@ -195,8 +198,9 @@ impl TaskStore {
             retention_policy: config.retention_policy,
             prune_interval: config.prune_interval,
             completion_count: std::sync::Arc::new(AtomicU64::new(0)),
-            // Conservative for file-backed stores that may have existing tags.
+            // Conservative for file-backed stores that may have existing tags/hierarchy.
             has_tags: std::sync::Arc::new(AtomicBool::new(true)),
+            has_hierarchy: std::sync::Arc::new(AtomicBool::new(true)),
         };
         store.migrate().await?;
         store.recover_running().await?;
@@ -221,8 +225,9 @@ impl TaskStore {
             retention_policy: Some(RetentionPolicy::MaxCount(10_000)),
             prune_interval: 100,
             completion_count: std::sync::Arc::new(AtomicU64::new(0)),
-            // In-memory stores start empty — no tags to query.
+            // In-memory stores start empty — no tags or hierarchy to query.
             has_tags: std::sync::Arc::new(AtomicBool::new(false)),
+            has_hierarchy: std::sync::Arc::new(AtomicBool::new(false)),
         };
         store.migrate().await?;
         Ok(store)

--- a/src/store/row_mapping.rs
+++ b/src/store/row_mapping.rs
@@ -10,13 +10,57 @@ use crate::task::{
 };
 
 pub(crate) fn parse_datetime(s: &str) -> DateTime<Utc> {
-    // SQLite stores as "YYYY-MM-DD HH:MM:SS" or "YYYY-MM-DD HH:MM:SS.mmm"
-    // (the latter from backoff-computed run_after). Try with fractional seconds
-    // first, then fall back to whole-second precision.
-    chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S%.f")
-        .or_else(|_| chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S"))
+    // SQLite stores as "YYYY-MM-DD HH:MM:SS" or "YYYY-MM-DD HH:MM:SS.mmm".
+    // Fast fixed-position byte parser instead of the generic chrono parser.
+    let b = s.as_bytes();
+    if b.len() < 19 {
+        return DateTime::<Utc>::default();
+    }
+
+    let year = parse_4(b, 0);
+    let month = parse_2(b, 5);
+    let day = parse_2(b, 8);
+    let hour = parse_2(b, 11);
+    let min = parse_2(b, 14);
+    let sec = parse_2(b, 17);
+
+    let nanos = if b.len() > 20 && b[19] == b'.' {
+        parse_frac_nanos(b, 20)
+    } else {
+        0
+    };
+
+    chrono::NaiveDate::from_ymd_opt(year, month, day)
+        .and_then(|d| d.and_hms_nano_opt(hour, min, sec, nanos))
         .map(|ndt| ndt.and_utc())
         .unwrap_or_default()
+}
+
+#[inline(always)]
+fn parse_2(b: &[u8], off: usize) -> u32 {
+    (b[off] - b'0') as u32 * 10 + (b[off + 1] - b'0') as u32
+}
+
+#[inline(always)]
+fn parse_4(b: &[u8], off: usize) -> i32 {
+    (b[off] - b'0') as i32 * 1000
+        + (b[off + 1] - b'0') as i32 * 100
+        + (b[off + 2] - b'0') as i32 * 10
+        + (b[off + 3] - b'0') as i32
+}
+
+#[inline(always)]
+fn parse_frac_nanos(b: &[u8], start: usize) -> u32 {
+    let frac_len = (b.len() - start).min(9);
+    let mut val: u32 = 0;
+    for i in 0..frac_len {
+        val = val * 10 + (b[start + i] - b'0') as u32;
+    }
+    // Pad to 9 digits (nanoseconds).
+    for _ in frac_len..9 {
+        val *= 10;
+    }
+    val
 }
 
 pub(crate) fn row_to_task_record(row: &sqlx::sqlite::SqliteRow) -> TaskRecord {
@@ -134,5 +178,41 @@ pub(crate) fn row_to_history_record(row: &sqlx::sqlite::SqliteRow) -> TaskHistor
         // Tags are populated separately from the task_history_tags table.
         tags: std::collections::HashMap::new(),
         max_retries: row.get("max_retries"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_whole_seconds() {
+        let dt = parse_datetime("2024-01-15 09:30:45");
+        assert_eq!(dt.to_string(), "2024-01-15 09:30:45 UTC");
+    }
+
+    #[test]
+    fn parse_fractional_millis() {
+        let dt = parse_datetime("2024-01-15 09:30:45.123");
+        assert_eq!(dt.to_string(), "2024-01-15 09:30:45.123 UTC");
+        assert_eq!(dt.timestamp_subsec_millis(), 123);
+    }
+
+    #[test]
+    fn parse_fractional_micros() {
+        let dt = parse_datetime("2024-01-15 09:30:45.123456");
+        assert_eq!(dt.to_string(), "2024-01-15 09:30:45.123456 UTC");
+    }
+
+    #[test]
+    fn parse_short_string_returns_default() {
+        let dt = parse_datetime("bad");
+        assert_eq!(dt, DateTime::<Utc>::default());
+    }
+
+    #[test]
+    fn parse_empty_returns_default() {
+        let dt = parse_datetime("");
+        assert_eq!(dt, DateTime::<Utc>::default());
     }
 }

--- a/src/store/submit/mod.rs
+++ b/src/store/submit/mod.rs
@@ -55,6 +55,7 @@ pub(crate) async fn submit_one(
     conn: &mut sqlx::pool::PoolConnection<sqlx::Sqlite>,
     sub: &TaskSubmission,
     has_tags_flag: Option<&std::sync::atomic::AtomicBool>,
+    has_hierarchy_flag: Option<&std::sync::atomic::AtomicBool>,
 ) -> Result<SubmitOutcome, StoreError> {
     if let Some(ref err) = sub.payload_error {
         return Err(StoreError::Serialization(err.clone()));
@@ -127,6 +128,13 @@ pub(crate) async fn submit_one(
     if result.rows_affected() > 0 {
         let task_id = result.last_insert_rowid();
 
+        // Mark hierarchy flag if this task has a parent.
+        if sub.parent_id.is_some() {
+            if let Some(flag) = has_hierarchy_flag {
+                flag.store(true, std::sync::atomic::Ordering::Relaxed);
+            }
+        }
+
         // Insert tags.
         if let Some(flag) = has_tags_flag {
             super::insert_tags_flagged(conn, task_id, &sub.tags, flag).await?;
@@ -188,7 +196,13 @@ impl TaskStore {
 
         let mut conn = self.begin_write().await?;
         tracing::debug!(task_type = %sub.task_type, "store.submit: INSERT start");
-        let outcome = submit_one(&mut conn, sub, Some(&self.has_tags)).await?;
+        let outcome = submit_one(
+            &mut conn,
+            sub,
+            Some(&self.has_tags),
+            Some(&self.has_hierarchy),
+        )
+        .await?;
         tracing::debug!(task_type = %sub.task_type, "store.submit: INSERT end");
         sqlx::query("COMMIT").execute(&mut *conn).await?;
         Ok(outcome)
@@ -242,7 +256,15 @@ impl TaskStore {
                 if last_occurrence[&sub.effective_key()] != global_i {
                     results.push(SubmitOutcome::Duplicate);
                 } else {
-                    results.push(submit_one(&mut conn, sub, Some(&self.has_tags)).await?);
+                    results.push(
+                        submit_one(
+                            &mut conn,
+                            sub,
+                            Some(&self.has_tags),
+                            Some(&self.has_hierarchy),
+                        )
+                        .await?,
+                    );
                 }
             }
 


### PR DESCRIPTION
## Summary

- Eliminate unnecessary SQL round-trips across the task dispatch and completion hot paths, cutting `dispatch_no_groups_500` latency by **~23%** (166ms → 128ms)
- Replace generic `chrono` datetime parser with a fixed-position byte parser for the known SQLite format
- Add `has_hierarchy` fast-path flag (following existing `has_tags` pattern) to skip the `active_children_count` query when no parent-child tasks exist
- Batch dependency resolution from 2+2N queries down to 2 using `DELETE … RETURNING` + single `UPDATE … RETURNING`
- Add `fast_dispatch` mode that uses `pop_next()` (1 SQL) instead of `peek_next()` + gate + `claim_task()` (2 SQL) when no groups, pressure sources, or module caps are configured

## Details

### 1. Inline `last_insert_rowid` (`store/lifecycle/mod.rs`)
`insert_history` was issuing a separate `SELECT last_insert_rowid()` query after every INSERT into `task_history`. The `SqliteQueryResult` already carries this value — use `result.last_insert_rowid()` directly, matching the existing pattern in `complete_inner`.

### 2. Fast datetime parsing (`store/row_mapping.rs`)
`parse_datetime` was calling `chrono::NaiveDateTime::parse_from_str` with a fallback — a generic parser invoked 2-4× per `row_to_task_record`. Replaced with a fixed-position byte parser that handles both `"YYYY-MM-DD HH:MM:SS"` and `"YYYY-MM-DD HH:MM:SS.fff…"`.

### 3. `has_hierarchy` flag (`store/mod.rs`, `scheduler/spawn/completion.rs`)
`handle_success` was calling `active_children_count` (a `SELECT COUNT(*)` query) for every task completion, even when no tasks use parent-child hierarchy. Added an `Arc<AtomicBool>` flag to `TaskStore` — set to `true` when a task with `parent_id` is submitted — and skip the query when `false`. Follows the existing `has_tags` pattern exactly.

### 4. Batched dependency resolution (`store/dependencies.rs`)
`resolve_dependents_inner` previously used SELECT + DELETE + per-dependent COUNT + UPDATE (2+2N queries). Now uses `DELETE FROM task_deps … RETURNING task_id` followed by a single `UPDATE tasks … WHERE id IN (…) AND NOT EXISTS (SELECT 1 FROM task_deps …) RETURNING id` — always 2 queries regardless of fan-out. Applied the same `DELETE … RETURNING` optimization to `fail_dependents_inner`.

### 5. Fast dispatch path (`scheduler/run_loop.rs`, `scheduler/builder.rs`)
When no groups, pressure sources, resource monitoring, or module caps are configured, `try_dispatch` now uses `pop_next()` (atomic UPDATE+RETURNING, 1 SQL) instead of `peek_next()` + `gate.admit()` + `claim_task()` (2 SQL). Added an expiry filter to `pop_next()`'s inner SELECT so expired tasks are safely skipped. The slow path is preserved unchanged as a fallback.

## Benchmark results

| Benchmark | Before | After | Change |
|-----------|--------|-------|--------|
| `dispatch_no_groups_500` | 166ms | 128ms | **-23%** |
| `dispatch_one_group_500` | 235ms | 170ms | **-28%** |
| `dispatch_group_scaling/100` | 234ms | 164ms | **-30%** |
| `dep_fan_in_dispatch/50` | 17.7ms | 14.3ms | **-19%** |
| `dep_fan_in_dispatch/100` | 34.5ms | 27.4ms | **-19%** |
