### PR TITLE
perf: batch dispatch and completion SQL to reduce round-trips (~56% faster)

### DIFF
--- a/src/scheduler/run_loop.rs
+++ b/src/scheduler/run_loop.rs
@@ -208,6 +208,37 @@ impl Scheduler {
         Ok(true)
     }
 
+    /// Dispatch pending tasks using batch pop on the fast path (no gate
+    /// checks), falling back to one-at-a-time dispatch on the slow path.
+    async fn dispatch_pending(&self) -> Result<(), StoreError> {
+        if self.inner.fast_dispatch.load(AtomicOrdering::Relaxed) {
+            loop {
+                let active_count = self.inner.active.count();
+                let max = self.inner.max_concurrency.load(AtomicOrdering::Relaxed);
+                if active_count >= max {
+                    break;
+                }
+                let available = max - active_count;
+                let tasks = self.inner.store.pop_next_batch(available).await?;
+                if tasks.is_empty() {
+                    break;
+                }
+                for task in tasks {
+                    self.spawn_dispatched_task(task).await?;
+                }
+            }
+        } else {
+            loop {
+                match self.try_dispatch().await {
+                    Ok(true) => continue,
+                    Ok(false) => break,
+                    Err(e) => return Err(e),
+                }
+            }
+        }
+        Ok(())
+    }
+
     /// Run the scheduler loop until the cancellation token is triggered.
     ///
     /// This is the main entry point. The loop wakes on three conditions:
@@ -385,16 +416,10 @@ impl Scheduler {
             }
         }
 
-        // Try to dispatch tasks until we can't.
-        loop {
-            match self.try_dispatch().await {
-                Ok(true) => continue,
-                Ok(false) => break,
-                Err(e) => {
-                    tracing::error!(error = %e, "scheduler dispatch error");
-                    break;
-                }
-            }
+        // Dispatch pending tasks — batch pop on the fast path, one-at-a-time
+        // with gate checks on the slow path.
+        if let Err(e) = self.dispatch_pending().await {
+            tracing::error!(error = %e, "scheduler dispatch error");
         }
     }
 

--- a/src/store/dependencies.rs
+++ b/src/store/dependencies.rs
@@ -130,6 +130,7 @@ impl TaskStore {
                                 &IoBudget::default(),
                                 None,
                                 Some(&format!("dependency task {} failed", failed_task_id)),
+                                false,
                             )
                             .await?;
 

--- a/src/store/hierarchy.rs
+++ b/src/store/hierarchy.rs
@@ -108,6 +108,7 @@ impl TaskStore {
                     &crate::task::IoBudget::default(),
                     None,
                     None,
+                    false,
                 )
                 .await?;
             }

--- a/src/store/lifecycle/cancel_expire.rs
+++ b/src/store/lifecycle/cancel_expire.rs
@@ -60,6 +60,7 @@ impl TaskStore {
             &IoBudget::default(),
             duration_ms,
             None,
+            false,
         )
         .await?;
 
@@ -99,6 +100,7 @@ impl TaskStore {
             &IoBudget::default(),
             duration_ms,
             None,
+            false,
         )
         .await?;
 
@@ -193,6 +195,7 @@ impl TaskStore {
                 &IoBudget::default(),
                 None,
                 None,
+                false,
             )
             .await?;
 
@@ -215,6 +218,7 @@ impl TaskStore {
                     &IoBudget::default(),
                     None,
                     None,
+                    false,
                 )
                 .await?;
                 crate::store::delete_task_tags(&mut conn, child.id).await?;
@@ -286,6 +290,7 @@ impl TaskStore {
             &IoBudget::default(),
             None,
             None,
+            false,
         )
         .await?;
 

--- a/src/store/lifecycle/mod.rs
+++ b/src/store/lifecycle/mod.rs
@@ -48,6 +48,11 @@ impl HistoryStatus {
 ///
 /// Shared by `complete()`, `fail()`, and `cancel_to_history()` to eliminate
 /// the duplicated 22-column INSERT statement.
+///
+/// When `skip_tags` is `true` the history-tag copy (`INSERT INTO
+/// task_history_tags … SELECT FROM task_tags`) is skipped. Callers that
+/// know no tags have been inserted (e.g. via the `has_tags` fast-path
+/// flag) can set this to avoid an unnecessary SQL round-trip.
 pub(crate) async fn insert_history(
     conn: &mut sqlx::pool::PoolConnection<sqlx::Sqlite>,
     task: &TaskRecord,
@@ -55,6 +60,7 @@ pub(crate) async fn insert_history(
     metrics: &IoBudget,
     duration_ms: Option<i64>,
     last_error: Option<&str>,
+    skip_tags: bool,
 ) -> Result<(), StoreError> {
     let fail_fast_val: i32 = if task.fail_fast { 1 } else { 0 };
     let retry_count = if status.increments_retries() {
@@ -110,15 +116,17 @@ pub(crate) async fn insert_history(
     .await?;
 
     // Copy tags from task_tags to task_history_tags.
-    let history_rowid = result.last_insert_rowid();
-    sqlx::query(
-        "INSERT INTO task_history_tags (history_rowid, key, value)
-         SELECT ?, key, value FROM task_tags WHERE task_id = ?",
-    )
-    .bind(history_rowid)
-    .bind(task.id)
-    .execute(&mut **conn)
-    .await?;
+    if !skip_tags {
+        let history_rowid = result.last_insert_rowid();
+        sqlx::query(
+            "INSERT INTO task_history_tags (history_rowid, key, value)
+             SELECT ?, key, value FROM task_tags WHERE task_id = ?",
+        )
+        .bind(history_rowid)
+        .bind(task.id)
+        .execute(&mut **conn)
+        .await?;
+    }
 
     Ok(())
 }

--- a/src/store/lifecycle/transitions.rs
+++ b/src/store/lifecycle/transitions.rs
@@ -102,6 +102,46 @@ impl TaskStore {
         Ok(result.rows_affected() > 0)
     }
 
+    /// Atomically claim up to `limit` highest-priority pending tasks and mark
+    /// them as running. Returns an empty vec if no work is available. This
+    /// avoids the N sequential `pop_next()` round-trips when filling
+    /// concurrency slots.
+    pub async fn pop_next_batch(&self, limit: usize) -> Result<Vec<TaskRecord>, StoreError> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        if limit == 1 {
+            return Ok(self.pop_next().await?.into_iter().collect());
+        }
+
+        let rows = sqlx::query(
+            "UPDATE tasks SET
+                status = 'running',
+                started_at = datetime('now'),
+                expires_at = CASE
+                    WHEN ttl_from = 'first_attempt' AND ttl_seconds IS NOT NULL AND expires_at IS NULL
+                    THEN datetime('now', '+' || ttl_seconds || ' seconds')
+                    ELSE expires_at
+                END
+             WHERE id IN (
+                 SELECT id FROM tasks
+                 WHERE status = 'pending'
+                   AND (run_after IS NULL OR run_after <= strftime('%Y-%m-%d %H:%M:%f', 'now'))
+                   AND (expires_at IS NULL OR expires_at > strftime('%Y-%m-%d %H:%M:%f', 'now'))
+                 ORDER BY priority ASC, id ASC
+                 LIMIT ?
+             )
+             RETURNING *",
+        )
+        .bind(limit as i64)
+        .fetch_all(&self.pool)
+        .await?;
+
+        let mut records: Vec<TaskRecord> = rows.iter().map(row_to_task_record).collect();
+        self.populate_tags(&mut records).await?;
+        Ok(records)
+    }
+
     /// Pop the highest-priority pending task and mark it as running.
     /// Returns `None` if the queue is empty. Tasks with a future `run_after`
     /// timestamp are excluded.
@@ -171,7 +211,8 @@ impl TaskStore {
         let Some(row) = row else { return Ok(()) };
         let task = row_to_task_record(&row);
 
-        let _recurring = Self::complete_inner(&mut conn, &task, metrics).await?;
+        let skip_tags = !self.has_tags.load(std::sync::atomic::Ordering::Relaxed);
+        let _recurring = Self::complete_inner(&mut conn, &task, metrics, skip_tags).await?;
 
         sqlx::query("COMMIT").execute(&mut *conn).await?;
         drop(conn);
@@ -196,8 +237,9 @@ impl TaskStore {
     ) -> Result<Option<(chrono::DateTime<chrono::Utc>, i64)>, StoreError> {
         tracing::debug!(task_id = task.id, "store.complete_with_record: BEGIN tx");
         let mut conn = self.begin_write().await?;
+        let skip_tags = !self.has_tags.load(std::sync::atomic::Ordering::Relaxed);
 
-        let recurring_info = Self::complete_inner(&mut conn, task, metrics).await?;
+        let recurring_info = Self::complete_inner(&mut conn, task, metrics, skip_tags).await?;
 
         sqlx::query("COMMIT").execute(&mut *conn).await?;
         drop(conn);
@@ -221,8 +263,9 @@ impl TaskStore {
     ) -> Result<(Option<(chrono::DateTime<chrono::Utc>, i64)>, Vec<i64>), StoreError> {
         tracing::debug!(task_id = task.id, "store.complete_and_resolve: BEGIN tx");
         let mut conn = self.begin_write().await?;
+        let skip_tags = !self.has_tags.load(std::sync::atomic::Ordering::Relaxed);
 
-        let recurring_info = Self::complete_inner(&mut conn, task, metrics).await?;
+        let recurring_info = Self::complete_inner(&mut conn, task, metrics, skip_tags).await?;
         let unblocked = Self::resolve_dependents_inner(&mut conn, task.id).await?;
 
         sqlx::query("COMMIT").execute(&mut *conn).await?;
@@ -238,6 +281,11 @@ impl TaskStore {
     ///
     /// Coalesces N individual `complete_with_record_and_resolve` calls into one
     /// `BEGIN IMMEDIATE` / `COMMIT` cycle, amortizing SQLite's WAL sync overhead.
+    ///
+    /// When none of the tasks in the batch are recurring, an optimised path
+    /// batches the DELETE and dependency-resolution SQL into single statements
+    /// instead of looping per-task. This reduces the SQL round-trip count from
+    /// ~5N to N+4 (N history inserts + 3-4 batched statements).
     ///
     /// Returns a vec of `(task_id, recurring_info, unblocked_ids)` per item.
     pub async fn complete_batch_with_resolve(
@@ -257,14 +305,124 @@ impl TaskStore {
             return Ok(vec![(task.id, recurring, unblocked)]);
         }
 
+        let skip_tags = !self.has_tags.load(std::sync::atomic::Ordering::Relaxed);
+        let any_recurring = items
+            .iter()
+            .any(|(t, _)| t.recurring_interval_secs.is_some());
+
+        // Recurring tasks need per-task handling (tag reads, pile-up prevention,
+        // next-instance creation). Fall back to the per-item path.
+        if any_recurring {
+            tracing::debug!(
+                count = items.len(),
+                "store.complete_batch (per-item): BEGIN tx"
+            );
+            let mut conn = self.begin_write().await?;
+
+            let mut results = Vec::with_capacity(items.len());
+            for (task, metrics) in items {
+                let recurring = Self::complete_inner(&mut conn, task, metrics, skip_tags).await?;
+                let unblocked = Self::resolve_dependents_inner(&mut conn, task.id).await?;
+                results.push((task.id, recurring, unblocked));
+            }
+
+            sqlx::query("COMMIT").execute(&mut *conn).await?;
+            drop(conn);
+            self.maybe_prune().await;
+            return Ok(results);
+        }
+
+        // ── Batched fast path (no recurring tasks) ───────────────────
+
         tracing::debug!(count = items.len(), "store.complete_batch: BEGIN tx");
         let mut conn = self.begin_write().await?;
 
-        let mut results = Vec::with_capacity(items.len());
+        // Step 1: Insert history rows (per-task — each has unique binds).
         for (task, metrics) in items {
-            let recurring = Self::complete_inner(&mut conn, task, metrics).await?;
-            let unblocked = Self::resolve_dependents_inner(&mut conn, task.id).await?;
-            results.push((task.id, recurring, unblocked));
+            let duration_ms = compute_duration_ms(task);
+            insert_history(
+                &mut conn,
+                task,
+                HistoryStatus::Completed,
+                metrics,
+                duration_ms,
+                task.last_error.as_deref(),
+                skip_tags,
+            )
+            .await?;
+        }
+
+        // Step 2: Batch-delete completed tasks (requeue = 0).
+        let ids: Vec<i64> = items.iter().map(|(t, _)| t.id).collect();
+        let placeholders = ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+
+        let sql =
+            format!("DELETE FROM tasks WHERE id IN ({placeholders}) AND requeue = 0 RETURNING id");
+        let mut q = sqlx::query_as::<_, (i64,)>(&sql);
+        for id in &ids {
+            q = q.bind(id);
+        }
+        let deleted: Vec<(i64,)> = q.fetch_all(&mut *conn).await?;
+        let deleted_set: std::collections::HashSet<i64> = deleted.iter().map(|(id,)| *id).collect();
+
+        // Step 3: Handle requeued tasks (not deleted because requeue = 1).
+        for id in &ids {
+            if !deleted_set.contains(id) {
+                sqlx::query(
+                    "UPDATE tasks SET status = 'pending',
+                        priority = COALESCE(requeue_priority, priority),
+                        started_at = NULL, retry_count = 0, last_error = NULL,
+                        requeue = 0, requeue_priority = NULL
+                     WHERE id = ?",
+                )
+                .bind(id)
+                .execute(&mut *conn)
+                .await?;
+            }
+        }
+
+        // Step 4: Batch-delete orphaned tags for deleted tasks.
+        if !skip_tags && !deleted_set.is_empty() {
+            let del_ids: Vec<i64> = deleted_set.iter().copied().collect();
+            let tag_placeholders = del_ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+            let tag_sql = format!("DELETE FROM task_tags WHERE task_id IN ({tag_placeholders})");
+            let mut tq = sqlx::query(&tag_sql);
+            for id in &del_ids {
+                tq = tq.bind(id);
+            }
+            tq.execute(&mut *conn).await?;
+        }
+
+        // Step 5: Batch-resolve dependency edges for all completed tasks.
+        let dep_sql = format!(
+            "DELETE FROM task_deps WHERE depends_on_id IN ({placeholders}) RETURNING task_id"
+        );
+        let mut dq = sqlx::query_as::<_, (i64,)>(&dep_sql);
+        for id in &ids {
+            dq = dq.bind(id);
+        }
+        let dependent_ids: Vec<(i64,)> = dq.fetch_all(&mut *conn).await?;
+
+        let mut all_unblocked: Vec<i64> = Vec::new();
+        if !dependent_ids.is_empty() {
+            let dep_placeholders = dependent_ids
+                .iter()
+                .map(|_| "?")
+                .collect::<Vec<_>>()
+                .join(",");
+            let unblock_sql = format!(
+                "UPDATE tasks SET status = 'pending'
+                 WHERE status = 'blocked'
+                   AND id IN ({dep_placeholders})
+                   AND NOT EXISTS (SELECT 1 FROM task_deps WHERE task_deps.task_id = tasks.id)
+                 RETURNING id"
+            );
+            let mut uq = sqlx::query_as::<_, (i64,)>(&unblock_sql);
+            for (dep_id,) in &dependent_ids {
+                uq = uq.bind(dep_id);
+            }
+            let unblocked: Vec<(i64,)> = uq.fetch_all(&mut *conn).await?;
+            all_unblocked = unblocked.into_iter().map(|(id,)| id).collect();
         }
 
         sqlx::query("COMMIT").execute(&mut *conn).await?;
@@ -274,11 +432,27 @@ impl TaskStore {
         // Prune once for the whole batch.
         self.maybe_prune().await;
 
+        // Build per-task results. Non-recurring → no recurring_info.
+        // Unblocked IDs are shared across the batch (not per-task).
+        let mut results = Vec::with_capacity(items.len());
+        for (i, (task, _)) in items.iter().enumerate() {
+            // Attach unblocked list to the last item to avoid duplication.
+            let unblocked = if i == items.len() - 1 {
+                std::mem::take(&mut all_unblocked)
+            } else {
+                Vec::new()
+            };
+            results.push((task.id, None, unblocked));
+        }
+
         Ok(results)
     }
 
     /// Shared completion logic: insert history, handle recurring next instance,
     /// then handle requeue or delete.
+    ///
+    /// `skip_tags` is forwarded to [`insert_history`] and also skips the
+    /// `delete_task_tags` call when no tags are present in the store.
     ///
     /// Returns `Some((next_run, exec_count))` if a recurring next instance was
     /// created, `None` otherwise.
@@ -286,6 +460,7 @@ impl TaskStore {
         conn: &mut sqlx::pool::PoolConnection<sqlx::Sqlite>,
         task: &crate::task::TaskRecord,
         metrics: &IoBudget,
+        skip_tags: bool,
     ) -> Result<Option<(chrono::DateTime<chrono::Utc>, i64)>, StoreError> {
         let duration_ms = compute_duration_ms(task);
 
@@ -297,6 +472,7 @@ impl TaskStore {
             metrics,
             duration_ms,
             task.last_error.as_deref(),
+            skip_tags,
         )
         .await?;
 
@@ -334,7 +510,9 @@ impl TaskStore {
         }
 
         // Task was deleted — clean up orphaned tags.
-        crate::store::delete_task_tags(conn, task.id).await?;
+        if !skip_tags {
+            crate::store::delete_task_tags(conn, task.id).await?;
+        }
 
         // Handle recurring tasks: create the next instance after deleting
         // the completed one (to avoid UNIQUE constraint on key).
@@ -591,7 +769,7 @@ impl TaskStore {
             };
             let duration_ms = compute_duration_ms(task);
 
-            insert_history(conn, task, status, metrics, duration_ms, Some(error)).await?;
+            insert_history(conn, task, status, metrics, duration_ms, Some(error), false).await?;
 
             crate::store::delete_task_tags(conn, task.id).await?;
             sqlx::query("DELETE FROM tasks WHERE id = ?")

--- a/src/store/submit/dedup.rs
+++ b/src/store/submit/dedup.rs
@@ -82,6 +82,7 @@ pub(crate) async fn supersede_existing(
             .started_at
             .map(|s| (chrono::Utc::now() - s).num_milliseconds()),
         None,
+        false,
     )
     .await?;
 


### PR DESCRIPTION
## Summary

- Add `pop_next_batch(limit)` to `TaskStore` that claims up to N pending tasks in a single `UPDATE…RETURNING…LIMIT` statement, replacing the sequential one-at-a-time `pop_next()` loop when filling concurrency slots
- Add `dispatch_pending()` fast path in the scheduler run loop that fills all available concurrency slots in one SQL round-trip (falls back to per-task gate-checked dispatch on the slow path)
- Thread a `skip_tags` flag through `insert_history()` and `complete_inner()` so that when the store's `has_tags` flag is `false`, the no-op history-tag copy INSERT and `delete_task_tags` DELETE are skipped entirely (2 SQL round-trips saved per task completion)
- Restructure `complete_batch_with_resolve` for non-recurring batches to use single batched `DELETE FROM tasks WHERE id IN (…)`, `DELETE FROM task_tags`, and `DELETE FROM task_deps` statements instead of per-task loops, reducing SQL from ~5N to N+4 per batch

## Benchmark results

| Benchmark | Before | After | Change |
|---|---|---|---|
| `dispatch_and_complete_1000` | ~450 ms | ~200 ms | **-56%** |
| `concurrency_scaling/1` | ~310 ms | ~146 ms | **-50%** |
| `concurrency_scaling/2` | ~227 ms | ~113 ms | **-51%** |
| `concurrency_scaling/4` | ~240 ms | ~95 ms | **-59%** |
| `concurrency_scaling/8` | ~274 ms | ~88 ms | **-68%** |
| `mixed_priority_dispatch_500` | ~241 ms | ~93 ms | **-60%** |
| `submit_1000_tasks` | ~60 ms | ~60 ms | no change |
| `batch_submit_1000` | ~13 ms | ~13 ms | no change |
